### PR TITLE
fix: Resolve syntax error in products module breaking application build

### DIFF
--- a/src/modules/products.js
+++ b/src/modules/products.js
@@ -316,6 +316,21 @@ export function initProducts(frame) {
           else renderTable();
         });
 
+        // Tabs
+        document.querySelectorAll('.tab').forEach(t => {
+          t.addEventListener('click', () => {
+            document.querySelectorAll('.tab').forEach(x => x.classList.remove('active'));
+            document.querySelectorAll('.tab-content').forEach(x => x.classList.remove('active'));
+            t.classList.add('active');
+            document.getElementById(t.getAttribute('data-target')).classList.add('active');
+          });
+        });
+
+        function openModal() { document.getElementById('modalProduct').classList.add('active'); }
+        function closeModal() { document.getElementById('modalProduct').classList.remove('active'); }
+        document.getElementById('btnCloseModal').addEventListener('click', closeModal);
+        document.getElementById('btnCancel').addEventListener('click', closeModal);
+
         // ── CSV Import (overlay avançado) ─────────────────────────────────────
         let productCsvRows = [];
         function parseCsv(text) {
@@ -443,21 +458,6 @@ export function initProducts(frame) {
           }
         });
 
-        // Tabs
-        document.querySelectorAll('.tab').forEach(t => {
-          t.addEventListener('click', () => {
-            document.querySelectorAll('.tab').forEach(x => x.classList.remove('active'));
-            document.querySelectorAll('.tab-content').forEach(x => x.classList.remove('active'));
-            t.classList.add('active');
-            document.getElementById(t.getAttribute('data-target')).classList.add('active');
-          });
-        });
-
-        function openModal() { document.getElementById('modalProduct').classList.add('active'); }
-        function closeModal() { document.getElementById('modalProduct').classList.remove('active'); }
-        document.getElementById('btnCloseModal').addEventListener('click', closeModal);
-        document.getElementById('btnCancel').addEventListener('click', closeModal);
-
         init();
       </script>
 
@@ -495,52 +495,6 @@ export function initProducts(frame) {
           <div id="prodImportResult" style="display:none;font-size:13px;padding:10px 0;"></div>
         </div>
       </div>
-    </body>
-    </html>
-  \`;
-  frame.srcdoc = html;
-}
-            is_active: document.getElementById('pActive').checked
-          };
-
-          let res;
-          if(id) {
-            res = await getSupabase().from('products').update(payload).eq('id', id);
-          } else {
-            res = await getSupabase().from('products').insert([payload]);
-          }
-
-          if(res.error) {
-            alert('Erro ao salvar: ' + res.error.message);
-          } else {
-            closeModal();
-            loadProducts();
-          }
-        });
-
-        document.getElementById('btnSearch').addEventListener('click', loadProducts);
-        document.getElementById('searchName').addEventListener('keyup', (e) => {
-           if(e.key === 'Enter') loadProducts();
-           else renderTable(); // live filter
-        });
-
-        // Tabs
-        document.querySelectorAll('.tab').forEach(t => {
-          t.addEventListener('click', () => {
-            document.querySelectorAll('.tab').forEach(x => x.classList.remove('active'));
-            document.querySelectorAll('.tab-content').forEach(x => x.classList.remove('active'));
-            t.classList.add('active');
-            document.getElementById(t.getAttribute('data-target')).classList.add('active');
-          });
-        });
-
-        function openModal() { document.getElementById('modalProduct').classList.add('active'); }
-        function closeModal() { document.getElementById('modalProduct').classList.remove('active'); }
-        document.getElementById('btnCloseModal').addEventListener('click', closeModal);
-        document.getElementById('btnCancel').addEventListener('click', closeModal);
-
-        init();
-      </script>
     </body>
     </html>
   `;


### PR DESCRIPTION
A malformed code block was incorrectly left in the middle of `src/modules/products.js` (presumably from a bad Git merge conflict resolution). Because `products.js` is imported by `main.js`, this single syntax error completely halted Vite's module bundling for the entire frontend application. This resulted in none of the modules loading correctly, thereby breaking the "Novo" buttons and "Importar CSV" features across *all* screens, including PDVs, Users (HC), and Products.

I have located and removed the extraneous syntax error closure (`</body></html>\`; frame.srcdoc = html; }`) around line 500, preserving the rest of the file's necessary logic. The build has been verified as passing locally with `npm run build`, and `node -c` has confirmed there are no remaining syntax errors in the module files. The frontend UI also successfully passed Playwright visual verification.

---
*PR created automatically by Jules for task [6511324056317120760](https://jules.google.com/task/6511324056317120760) started by @waggnerog*